### PR TITLE
added language support

### DIFF
--- a/src/org/mumumu/ti/android/speech/VoiceRecognitionProxy.java
+++ b/src/org/mumumu/ti/android/speech/VoiceRecognitionProxy.java
@@ -62,6 +62,11 @@ public class VoiceRecognitionProxy extends KrollProxy implements TiActivityResul
             	Log.d(TAG, "overriding RecognizerIntent.EXTRA_PROMPT value");
                	intent.putExtra(RecognizerIntent.EXTRA_PROMPT, extraVal);
             }
+            if (options.containsKey(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE)) {
+            	String extraVal = (String)options.get(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE);
+            	Log.d(TAG, "overriding RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE value");
+               	intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, extraVal);
+            }            
         }
         TiApplication.getInstance().getRootActivity().launchActivityForResult(intent, VOICE_RECOGNITION_REQUEST_CODE, this);
     }


### PR DESCRIPTION
from: http://stackoverflow.com/questions/10538791/how-to-set-the-language-in-speech-recognition-on-android

Needs to be tested (sorry) but it should work like this:

``` javascript
voiceRecognitionProxy.voiceRecognition({
   "android.speech.extra.PROMPT": "please say something",
   "android.speech.extra.LANGUAGE_MODEL": "free_form",
   "android.speech.extra.LANGUAGE_PREFERENCE": "en-US",
   "callback": callback_func
});
```
